### PR TITLE
#79 Delete node on mainnet

### DIFF
--- a/services/community-site/src/pages/RunNode/RunNode.tsx
+++ b/services/community-site/src/pages/RunNode/RunNode.tsx
@@ -314,21 +314,20 @@ const RunNode = () => {
             setCurrentEditedNode(node);
           }}
         />
-        {(node.canDelete || node.totalDelegation === 0) && (
-          <Button
-            size="small"
-            label="Delete"
-            className="delete"
-            onClick={() => {
-              const confirmation = window.confirm(
-                "Are you sure you want to delete this node? You won't be able to add a node with the same wallet address.",
-              );
-              if (confirmation) {
-                deleteNode(node);
-              }
-            }}
-          />
-        )}
+        <Button
+          size="small"
+          label="Delete"
+          className="delete"
+          disabled={!node.canDelete}
+          onClick={() => {
+            const confirmation = window.confirm(
+              "Are you sure you want to delete this node? You won't be able to add a node with the same wallet address.",
+            );
+            if (confirmation) {
+              deleteNode(node);
+            }
+          }}
+        />
       </>
     );
 

--- a/services/community-site/src/pages/RunNode/RunNode.tsx
+++ b/services/community-site/src/pages/RunNode/RunNode.tsx
@@ -314,7 +314,7 @@ const RunNode = () => {
             setCurrentEditedNode(node);
           }}
         />
-        {node.canDelete && (
+        {(node.canDelete || node.totalDelegation === 0) && (
           <Button
             size="small"
             label="Delete"


### PR DESCRIPTION
Fixes #79 
This ticket allows deleting nodes when `canDelete` is true or if there are no delegations to that node.