### PR TITLE
changes URI pattern to match new endpoint

### DIFF
--- a/services/delegation/charts/community-delegation/templates/configmap.yaml
+++ b/services/delegation/charts/community-delegation/templates/configmap.yaml
@@ -14,8 +14,8 @@ data:
   STAKING_CONTRACT_ADDRESS: {{ .Values.app.stakingContractAddress | quote }}
   MAINNET_ENDPOINT: {{ .Values.app.mainnetEndpoint | quote }}
   TESTNET_ENDPOINT: {{ .Values.app.testnetEndpoint | quote }}
-  MAINNET_EXPLORER_URL: {{ .Values.app.mainnetExplorerUrl | quote }}
-  TESTNET_EXPLORER_URL: {{ .Values.app.testnetExplorerUrl | quote }}
+  MAINNET_INDEXER_URL: {{ .Values.app.mainnetIndexerUrl | quote }}
+  TESTNET_INDEXER_URL: {{ .Values.app.testnetIndexerUrl | quote }}
   INDEXER_STAKING_URL: {{ .Values.app.indexerStakingUrl | quote }}
   TESTNET_OWN_NODES: {{ .Values.app.testnetOwnNodes | toJson | quote }}
   NODE_ENV: {{ .Values.app.environment | quote }}

--- a/services/delegation/charts/prod.values.yaml
+++ b/services/delegation/charts/prod.values.yaml
@@ -10,8 +10,8 @@ app:
   stakingContractAddress: "0x7Af59Ea121a8Da8e49d2d44856feB7761561995b"
   mainnetEndpoint: "https://rpc.mainnet.taraxa.io"
   testnetEndpoint: "https://rpc.testnet.taraxa.io"
-  mainnetExplorerUrl: "https://explorer.mainnet.taraxa.io"
-  testnetExplorerUrl: "https://explorer.testnet.taraxa.io"
+  mainnetIndexerUrl: "https://indexer.mainnet.taraxa.io"
+  testnetIndexerUrl: "https://indexer.testnet.taraxa.io"
   indexerStakingUrl: http://prod-taraxa-indexer:8000/subgraphs/name/taraxa_project/staking
   testnetOwnNodes:
     - "0x18551e353aa65bc0ffbdf9d93b7ad4a8fe29cf95"

--- a/services/delegation/charts/qa.values.yaml
+++ b/services/delegation/charts/qa.values.yaml
@@ -9,8 +9,8 @@ app:
   stakingContractAddress: "0x7Af59Ea121a8Da8e49d2d44856feB7761561995b"
   mainnetEndpoint: "https://rpc.mainnet.taraxa.io"
   testnetEndpoint: "https://rpc.testnet.taraxa.io"
-  mainnetExplorerUrl: "https://explorer.mainnet.taraxa.io"
-  testnetExplorerUrl: "https://explorer.testnet.taraxa.io"
+  mainnetIndexerUrl: "https://indexer.mainnet.taraxa.io"
+  testnetIndexerUrl: "https://indexer.testnet.taraxa.io"
   indexerStakingUrl: http://qa-taraxa-indexer:8000/subgraphs/name/taraxa_project/staking
   testnetOwnNodes:
     - "0x18551e353aa65bc0ffbdf9d93b7ad4a8fe29cf95"

--- a/services/delegation/src/config/ethereum.ts
+++ b/services/delegation/src/config/ethereum.ts
@@ -6,6 +6,6 @@ export default registerAs('ethereum', () => ({
   mainnetWallet: process.env.MAINNET_WALLET,
   testnetEndpoint: process.env.TESTNET_ENDPOINT,
   testnetWallet: process.env.TESTNET_WALLET,
-  mainnetExplorerUrl: process.env.MAINNET_EXPLORER_URL,
-  testnetExplorerUrl: process.env.TESTNET_EXPLORER_URL,
+  mainnetIndexerUrl: process.env.MAINNET_INDEXER_URL,
+  testnetIndexerUrl: process.env.TESTNET_INDEXER_URL,
 }));

--- a/services/delegation/src/modules/node/node-task.service.ts
+++ b/services/delegation/src/modules/node/node-task.service.ts
@@ -39,7 +39,7 @@ export class NodeTaskService implements OnModuleInit {
           nodes.length
         }: getting stats for node ${node.address.toLowerCase()}`,
       );
-      const uri = `/api/address/${node.address.toLowerCase()}/stats`;
+      const uri = `/address/${node.address.toLowerCase()}/stats`;
       const url =
         node.type === NodeType.MAINNET
           ? `${mainnetExplorerUrl}${uri}`

--- a/services/delegation/src/modules/utils/interfaces.ts
+++ b/services/delegation/src/modules/utils/interfaces.ts
@@ -1,0 +1,13 @@
+export interface NodeStatsReponse {
+  dagsCount: number;
+  pbftCount: number;
+  transactionsCount: number;
+  lastDagTimestamp: number;
+  lastPbftTimestamp: number;
+}
+
+export interface AddressDetailsResponse {
+  address: string;
+  pbftCount: number;
+  rank: number;
+}

--- a/services/delegation/src/modules/utils/utils.ts
+++ b/services/delegation/src/modules/utils/utils.ts
@@ -1,0 +1,26 @@
+import { HttpService } from '@nestjs/axios';
+import { catchError, firstValueFrom, map } from 'rxjs';
+
+export async function get<T>(
+  httpService: HttpService,
+  url: string,
+  errorMsg: string,
+): Promise<T> {
+  return await firstValueFrom(
+    httpService
+      .get(url, {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      .pipe(
+        map((res) => {
+          return res.data;
+        }),
+        catchError((err, caught) => {
+          this.logger.error(`${errorMsg} - Error: ${err}`);
+          return caught;
+        }),
+      ),
+  );
+}


### PR DESCRIPTION
1. Delegation page call is already changed in the parent branch
2. Fixed URI pattern for delegation service
3. Before deploying delegation both  `mainnetExplorerUrl: process.env.MAINNET_EXPLORER_URL` and `testnetExplorerUrl: process.env.TESTNET_EXPLORER_URL` need to be set to their respective indexer endpoints.